### PR TITLE
Support arm64 architecture for M1 mac

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -48,6 +48,7 @@ install_alp() {
     x86_64) architecture="amd64" ;;
     i386 | i686) architecture="386" ;;
     arm | aarch64) architecture="arm" ;;
+    arm64) architecture="arm64" ;;
     *) fail "Unsupported architecture" ;;
   esac
 


### PR DESCRIPTION
alp supports arm64 binary from version `1.0.9`.
ref. https://github.com/tkuchiki/alp/issues/62

So this plugin can support arm64 by adding a condition.