### PR TITLE
Fix escape for fail message coloring

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -18,7 +18,8 @@
 set -eo pipefail
 
 fail() {
-  echo -e "\e[31mFail:\e[m $*"
+  ESC=$(printf '\33')
+  echo "${ESC}[31mFail:${ESC}[m $*"
   exit 1
 }
 


### PR DESCRIPTION
In my shell, fail message was not escaped.
```sh
$ asdf install alp 1.0.9
\e[31mFail:\e[m Unsupported architecture
```

The cause is unknown , but there seems to be a shell-independent escaping specification, so I took care of that.
ref. https://qiita.com/ko1nksm/items/095bdb8f0eca6d327233
```sh
ESC=$(printf '\33')
echo "${ESC}[31mFail:${ESC}[m $*"
```

Please close this PR if it is inappropriate.

---

my environment)
- Shell: zsh
- Zsh Framework: prezto (theme: pure)